### PR TITLE
HttpServerUtility.MapPath replaced with HostingEnvironment.MapPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Webpack.NET
 
-Integrating webpack into ASP.NET MVC projects.
+Integrating webpack into Sitecore ASP.NET MVC projects.
 
 ## Asset Caching
 Caching is good <sup>[citation needed]</sup>.  The [webpack documentation](https://webpack.js.org/guides/caching/#components/sidebar/sidebar.jsx) has a good description of the problem and proposed solution for caching of webpack assets so this focuses on how that can be integrated into your ASP.NET MVC project.

--- a/Webpack.NET.Tests/TestConfigurationExtensions.cs
+++ b/Webpack.NET.Tests/TestConfigurationExtensions.cs
@@ -14,7 +14,8 @@ namespace Webpack.NET.Tests
             var pathMappingService = new Mock<IPathMappingService>();
             HttpApplication application = null;
             Assert.Throws<ArgumentNullException>(() => application.ConfigureWebpack(pathMappingService.Object, new WebpackConfig()));
-            Assert.Throws<ArgumentNullException>(() => new HttpApplication().ConfigureWebpack(null));
+            Assert.Throws<ArgumentNullException>(() => new HttpApplication().ConfigureWebpack((IPathMappingService)null));
+            Assert.Throws<ArgumentNullException>(() => new HttpApplication().ConfigureWebpack((WebpackConfig[])null));
         }
 
         [Test]

--- a/Webpack.NET.Tests/TestConfigurationExtensions.cs
+++ b/Webpack.NET.Tests/TestConfigurationExtensions.cs
@@ -11,8 +11,9 @@ namespace Webpack.NET.Tests
         [Test]
         public void ConfigureWebpack_Throws_On_Null_Parameters()
         {
+            var pathMappingService = new Mock<IPathMappingService>();
             HttpApplication application = null;
-            Assert.Throws<ArgumentNullException>(() => application.ConfigureWebpack(new WebpackConfig()));
+            Assert.Throws<ArgumentNullException>(() => application.ConfigureWebpack(pathMappingService.Object, new WebpackConfig()));
             Assert.Throws<ArgumentNullException>(() => new HttpApplication().ConfigureWebpack(null));
         }
 

--- a/Webpack.NET/ConfigurationExtensions.cs
+++ b/Webpack.NET/ConfigurationExtensions.cs
@@ -21,6 +21,22 @@ namespace Webpack.NET
         /// <param name="configurations">The webpack configurations.</param>
         /// <exception cref="System.ArgumentNullException">application</exception>
         [ExcludeFromCodeCoverage]
+        public static void ConfigureWebpack(this HttpApplication application, params WebpackConfig[] configurations)
+        {
+            if (application == null) throw new ArgumentNullException(nameof(application));
+
+            new HttpApplicationStateWrapper(application.Application)
+                    .ConfigureWebpack(new Webpack(configurations));
+        }
+
+        /// <summary>
+        /// Configures webpack.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="pathMappingService">Service responsible for mapping paths</param>
+        /// <param name="configurations">The webpack configurations.</param>
+        /// <exception cref="System.ArgumentNullException">application</exception>
+        [ExcludeFromCodeCoverage]
         public static void ConfigureWebpack(this HttpApplication application, IPathMappingService pathMappingService, params WebpackConfig[] configurations)
         {
             if (application == null) throw new ArgumentNullException(nameof(application));

--- a/Webpack.NET/ConfigurationExtensions.cs
+++ b/Webpack.NET/ConfigurationExtensions.cs
@@ -21,12 +21,12 @@ namespace Webpack.NET
         /// <param name="configurations">The webpack configurations.</param>
         /// <exception cref="System.ArgumentNullException">application</exception>
         [ExcludeFromCodeCoverage]
-        public static void ConfigureWebpack(this HttpApplication application, params WebpackConfig[] configurations)
+        public static void ConfigureWebpack(this HttpApplication application, IPathMappingService pathMappingService, params WebpackConfig[] configurations)
         {
             if (application == null) throw new ArgumentNullException(nameof(application));
 
             new HttpApplicationStateWrapper(application.Application)
-                    .ConfigureWebpack(new Webpack(configurations, new HttpServerUtilityWrapper(application.Server)));
+                    .ConfigureWebpack(new Webpack(configurations, pathMappingService));
         }
 
         /// <summary>

--- a/Webpack.NET/IPathMappingService.cs
+++ b/Webpack.NET/IPathMappingService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Webpack.NET
+{
+    public interface IPathMappingService
+    {
+        string MapPath(string path);
+    }
+}

--- a/Webpack.NET/PathMappingService.cs
+++ b/Webpack.NET/PathMappingService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Hosting;
+
+namespace Webpack.NET
+{
+    public class PathMappingService : IPathMappingService
+    {
+        public string MapPath(string path)
+        {
+            return HostingEnvironment.MapPath(path);
+        }
+    }
+}

--- a/Webpack.NET/Webpack.NET.csproj
+++ b/Webpack.NET/Webpack.NET.csproj
@@ -72,7 +72,9 @@
     <Compile Include="AssetNotFoundException.cs" />
     <Compile Include="ConfigurationExtensions.cs" />
     <Compile Include="HtmlHelperExtensions.cs" />
+    <Compile Include="IPathMappingService.cs" />
     <Compile Include="IWebpack.cs" />
+    <Compile Include="PathMappingService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UrlHelperExtensions.cs" />
     <Compile Include="Webpack.cs" />

--- a/Webpack.NET/Webpack.cs
+++ b/Webpack.NET/Webpack.cs
@@ -6,87 +6,100 @@ using System.Web.Hosting;
 
 namespace Webpack.NET
 {
-	/// <summary>
-	/// Implementation of configured webpack instance.
-	/// </summary>
-	/// <seealso cref="Webpack.NET.IWebpack" />
-	internal class Webpack : IWebpack
-	{
-		/// <summary>
-		/// The cached assets.
-		/// </summary>
-		private readonly Lazy<IEnumerable<WebpackAssetsDictionary>> assets;
+    /// <summary>
+    /// Implementation of configured webpack instance.
+    /// </summary>
+    /// <seealso cref="Webpack.NET.IWebpack" />
+    internal class Webpack : IWebpack
+    {
+        /// <summary>
+        /// The cached assets.
+        /// </summary>
+        private readonly Lazy<IEnumerable<WebpackAssetsDictionary>> assets;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="Webpack" /> class.
-		/// </summary>
-		/// <param name="configurations">The webpack configurations.</param>
-		/// <param name="httpServerUtility">The HTTP server utility.</param>
-		/// <exception cref="System.ArgumentNullException">configs
-		/// or
-		/// server</exception>
-		public Webpack(IEnumerable<WebpackConfig> configurations, IPathMappingService pathMappingService)
-		{
-			if (configurations == null) throw new ArgumentNullException(nameof(configurations));
-			if (pathMappingService == null) throw new ArgumentNullException(nameof(pathMappingService));
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Webpack" /> class.
+        /// Uses default <see cref="PathMappingService"/> to map paths.
+        /// </summary>
+        /// <param name="configurations">The webpack configurations.</param>
+        /// <exception cref="System.ArgumentNullException">configs
+        /// or
+        /// server</exception>
+        public Webpack(IEnumerable<WebpackConfig> configurations)
+            : this(configurations, new PathMappingService())
+        {
+        }
 
-			this.assets = new Lazy<IEnumerable<WebpackAssetsDictionary>>(() => configurations
-				.Select(config => GetAssetDictionaryForConfig(config, pathMappingService))
-				.ToList());
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Webpack" /> class.
+        /// </summary>
+        /// <param name="configurations">The webpack configurations.</param>
+        /// <param name="httpServerUtility">The HTTP server utility.</param>
+        /// <exception cref="System.ArgumentNullException">configs
+        /// or
+        /// server</exception>
+        public Webpack(IEnumerable<WebpackConfig> configurations, IPathMappingService pathMappingService)
+        {
+            if (configurations == null) throw new ArgumentNullException(nameof(configurations));
+            if (pathMappingService == null) throw new ArgumentNullException(nameof(pathMappingService));
 
-		/// <summary>
-		/// Gets the webpack asset dictionary for the specified <paramref name="configuration"/>.
-		/// </summary>
-		/// <param name="configuration">The webpack configuration.</param>
-		/// <param name="httpServerUtility">The HTTP server utility.</param>
-		/// <returns>
-		/// The webpack asset dictionary.
-		/// </returns>
-		private static WebpackAssetsDictionary GetAssetDictionaryForConfig(WebpackConfig configuration, IPathMappingService pathMappingService)
-		{
-			var assets = WebpackAssetsDictionary.FromFile(pathMappingService.MapPath(configuration.AssetManifestPath));
-			assets.RootFolder = configuration.AssetOutputPath;
+            this.assets = new Lazy<IEnumerable<WebpackAssetsDictionary>>(() => configurations
+                .Select(config => GetAssetDictionaryForConfig(config, pathMappingService))
+                .ToList());
+        }
 
-			return assets;
-		}
+        /// <summary>
+        /// Gets the webpack asset dictionary for the specified <paramref name="configuration"/>.
+        /// </summary>
+        /// <param name="configuration">The webpack configuration.</param>
+        /// <param name="httpServerUtility">The HTTP server utility.</param>
+        /// <returns>
+        /// The webpack asset dictionary.
+        /// </returns>
+        private static WebpackAssetsDictionary GetAssetDictionaryForConfig(WebpackConfig configuration, IPathMappingService pathMappingService)
+        {
+            var assets = WebpackAssetsDictionary.FromFile(pathMappingService.MapPath(configuration.AssetManifestPath));
+            assets.RootFolder = configuration.AssetOutputPath;
 
-		/// <summary>
-		/// Gets the asset URL.
-		/// </summary>
-		/// <param name="assetName">Name of the asset.</param>
-		/// <param name="assetType">Type of the asset.</param>
-		/// <param name="required">If set to <c>true</c> throws an <see cref="AssetNotFoundException" /> when the asset could not be found; otherwise, returns <c>null</c>.</param>
-		/// <returns>
-		/// The asset URL.
-		/// </returns>
-		/// <exception cref="AssetNotFoundException">Asset '<paramref name="assetName" />' with type '<paramref name="assetType" />' could not be found.</exception>
-		public string GetAssetUrl(string assetName, string assetType, bool required = true)
-		{
-			var matchingDictionary = this.assets.Value
-				.Where(a => a.ContainsKey(assetName))
-				.FirstOrDefault();
+            return assets;
+        }
 
-			string assetUrl = null;
-			var noAssetFound = matchingDictionary == null || !matchingDictionary[assetName].TryGetValue(assetType, out assetUrl);
-			if (noAssetFound)
-			{
-				if (required) throw new AssetNotFoundException(assetName, assetType);
+        /// <summary>
+        /// Gets the asset URL.
+        /// </summary>
+        /// <param name="assetName">Name of the asset.</param>
+        /// <param name="assetType">Type of the asset.</param>
+        /// <param name="required">If set to <c>true</c> throws an <see cref="AssetNotFoundException" /> when the asset could not be found; otherwise, returns <c>null</c>.</param>
+        /// <returns>
+        /// The asset URL.
+        /// </returns>
+        /// <exception cref="AssetNotFoundException">Asset '<paramref name="assetName" />' with type '<paramref name="assetType" />' could not be found.</exception>
+        public string GetAssetUrl(string assetName, string assetType, bool required = true)
+        {
+            var matchingDictionary = this.assets.Value
+                .Where(a => a.ContainsKey(assetName))
+                .FirstOrDefault();
 
-				return null;
-			}
+            string assetUrl = null;
+            var noAssetFound = matchingDictionary == null || !matchingDictionary[assetName].TryGetValue(assetType, out assetUrl);
+            if (noAssetFound)
+            {
+                if (required) throw new AssetNotFoundException(assetName, assetType);
 
-			string rootFolder = matchingDictionary.RootFolder;
-			if (String.IsNullOrEmpty(rootFolder) || Uri.IsWellFormedUriString(assetUrl, UriKind.Absolute))
-			{
-				// No root folder set or asset is already an absolute URL
-				return assetUrl;
-			}
-			else
-			{
-				// Combine root folder and asset URL
-				return $"{rootFolder}/{assetUrl}";
-			}
-		}
-	}
+                return null;
+            }
+
+            string rootFolder = matchingDictionary.RootFolder;
+            if (String.IsNullOrEmpty(rootFolder) || Uri.IsWellFormedUriString(assetUrl, UriKind.Absolute))
+            {
+                // No root folder set or asset is already an absolute URL
+                return assetUrl;
+            }
+            else
+            {
+                // Combine root folder and asset URL
+                return $"{rootFolder}/{assetUrl}";
+            }
+        }
+    }
 }

--- a/Webpack.NET/Webpack.cs
+++ b/Webpack.NET/Webpack.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using System.Web.Hosting;
 
 namespace Webpack.NET
 {
@@ -24,13 +25,13 @@ namespace Webpack.NET
 		/// <exception cref="System.ArgumentNullException">configs
 		/// or
 		/// server</exception>
-		public Webpack(IEnumerable<WebpackConfig> configurations, HttpServerUtilityBase httpServerUtility)
+		public Webpack(IEnumerable<WebpackConfig> configurations, IPathMappingService pathMappingService)
 		{
 			if (configurations == null) throw new ArgumentNullException(nameof(configurations));
-			if (httpServerUtility == null) throw new ArgumentNullException(nameof(httpServerUtility));
+			if (pathMappingService == null) throw new ArgumentNullException(nameof(pathMappingService));
 
 			this.assets = new Lazy<IEnumerable<WebpackAssetsDictionary>>(() => configurations
-				.Select(config => GetAssetDictionaryForConfig(config, httpServerUtility))
+				.Select(config => GetAssetDictionaryForConfig(config, pathMappingService))
 				.ToList());
 		}
 
@@ -42,9 +43,9 @@ namespace Webpack.NET
 		/// <returns>
 		/// The webpack asset dictionary.
 		/// </returns>
-		private static WebpackAssetsDictionary GetAssetDictionaryForConfig(WebpackConfig configuration, HttpServerUtilityBase httpServerUtility)
+		private static WebpackAssetsDictionary GetAssetDictionaryForConfig(WebpackConfig configuration, IPathMappingService pathMappingService)
 		{
-			var assets = WebpackAssetsDictionary.FromFile(httpServerUtility.MapPath(configuration.AssetManifestPath));
+			var assets = WebpackAssetsDictionary.FromFile(pathMappingService.MapPath(configuration.AssetManifestPath));
 			assets.RootFolder = configuration.AssetOutputPath;
 
 			return assets;


### PR DESCRIPTION
HttpServerUtility replaced with own service that utilizes HostingEnvironment.MapPath method so it does not require HttpContext to exist.

In Sitecore 9, during the initialize pipeline HttpApplication.Server object is initialized differently than in normal ASP.NET MVC application, in Application_Start.
Details are described in reported issue https://github.com/EDGE10/Webpack.NET/issues/9.